### PR TITLE
ci: add golangci-lint config v2 and enforce linting

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -7,17 +7,28 @@ on:
       - 'v*'
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v6
+      with:
+        version: latest
+
   build:
     name: Build check
     runs-on: ubuntu-latest
-    # needs: [lint, error_check, static_check, vet, sec_check, tests]
+    needs: [lint] # Endi build linterdan o'tmaguncha ishlamaydi
     steps:
     - name: Check out code
-      uses: actions/checkout@master
+      uses: actions/checkout@v4
       with:
         fetch-depth: 1
     - name: Setup Go
-      uses: actions/setup-go@master
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ secrets.GO_VERSION }}
     - run: GOPROXY=direct GOSUMDB=off GO111MODULE=on go build .

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,36 @@
+version: 2
+
+run:
+  timeout: 5m
+  skip-dirs:
+    - vendor
+    - hack
+    - helpers
+
+linters-settings:
+  staticcheck:
+    checks: ["all", "-ST1005"]
+  govet:
+    check-shadowing: false
+  lll:
+    line-length: 120
+
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - gofmt
+    - goimports
+    - govet
+    - misspell
+    - staticcheck
+    - stylecheck
+    - whitespace
+    - unused
+    - revive
+
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - errcheck


### PR DESCRIPTION
### Description
This PR introduces the `golangci-lint` configuration (v2) to the `meshery-app-mesh` repository. Previously, this adapter lacked automated code quality checks. By adding this configuration and updating the GitHub Actions workflow, we ensure that all future contributions adhere to the Meshery project's coding standards.

### Notes for Reviewers
* Created `.golangci.yml` from scratch with version 2 standards.
* Added a dedicated `lint` job to the `build-and-release.yml` workflow.
* Configured the `build` job to depend on the `lint` job (`needs: [lint]`), ensuring that only lint-clean code is built.
* Updated GitHub Actions steps to use the latest versions (`actions/checkout@v4` and `actions/setup-go@v5`).
* Verified that the `DCO` (Developer Certificate of Origin) is signed.

### Signed commits
- [x] Yes, I signed my commits.