### PR TITLE
Chore/upgrade go 1.26.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 as builder
+FROM golang:1.26.4 as builder
 
 ARG VERSION
 ARG GIT_COMMITSHA

--- a/appmesh/oam.go
+++ b/appmesh/oam.go
@@ -197,7 +197,7 @@ func mergeErrors(errs []error) error {
 		errMsgs = append(errMsgs, err.Error())
 	}
 
-	return fmt.Errorf(strings.Join(errMsgs, "\n"))
+	return fmt.Errorf("%s", strings.Join(errMsgs, "\n"))
 }
 
 func mergeMsgs(strs []string) string {

--- a/build/Makefile.core.mk
+++ b/build/Makefile.core.mk
@@ -19,7 +19,7 @@ GIT_VERSION	= $(shell git describe --tags `git rev-list --tags --max-count=1`)
 GIT_COMMITSHA = $(shell git rev-list -1 HEAD)
 GIT_STRIPPED_VERSION=$(shell git describe --tags `git rev-list --tags --max-count=1` | cut -c 2-)
 
-GOVERSION = 1.23
+GOVERSION = 1.26.4
 GOPATH = $(shell go env GOPATH)
 GOBIN  = $(GOPATH)/bin
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/layer5io/meshery-app-mesh
 
-go 1.23
+go 1.26.4
 
 replace (
 	github.com/kudobuilder/kuttl => github.com/layer5io/kuttl v0.4.1-0.20200723152044-916f10574334


### PR DESCRIPTION
**Description**

Upgrade Go version from 1.23 to 1.26.4.

**Fixes:** meshery/meshery#19875

**Verified with:**

- `go build ./...`
- `go test ./...`
- `go vet ./...`

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 